### PR TITLE
Add an activator base on configuration

### DIFF
--- a/MAF.FeaturesFlipping.sln
+++ b/MAF.FeaturesFlipping.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{25D7998E-82BA-4740-ADD5-86FF5A2E5B23}"
 EndProject
@@ -64,6 +64,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "aspnet", "aspnet", "{087E0A
 		docs\aspnet\index.md = docs\aspnet\index.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MAF.FeaturesFlipping.Activators.Configuration", "src\activators\MAF.FeaturesFlipping.Activators.Configuration\MAF.FeaturesFlipping.Activators.Configuration.csproj", "{EFA8175B-26B8-46DF-AE0C-C6669C5A47E6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration", "src\di\MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration\MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration.csproj", "{B271804C-0B8F-404E-AC95-C5F21CD7E248}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MAF.FeaturesFlipping.Activators.Configuration.UnitTests", "tests\activators\MAF.FeaturesFlipping.Activators.Configuration.UnitTests\MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj", "{AAC8BF03-AFE4-4108-961F-5A0CA69FDC91}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "activators", "activators", "{37F031BF-EB4F-4D3A-8BA9-B25E82783ECB}"
+	ProjectSection(SolutionItems) = preProject
+		configuration.md = configuration.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +129,18 @@ Global
 		{B923E1DA-5A49-4692-8AC9-A050ED657C69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B923E1DA-5A49-4692-8AC9-A050ED657C69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B923E1DA-5A49-4692-8AC9-A050ED657C69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFA8175B-26B8-46DF-AE0C-C6669C5A47E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFA8175B-26B8-46DF-AE0C-C6669C5A47E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFA8175B-26B8-46DF-AE0C-C6669C5A47E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFA8175B-26B8-46DF-AE0C-C6669C5A47E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B271804C-0B8F-404E-AC95-C5F21CD7E248}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B271804C-0B8F-404E-AC95-C5F21CD7E248}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B271804C-0B8F-404E-AC95-C5F21CD7E248}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B271804C-0B8F-404E-AC95-C5F21CD7E248}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAC8BF03-AFE4-4108-961F-5A0CA69FDC91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAC8BF03-AFE4-4108-961F-5A0CA69FDC91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAC8BF03-AFE4-4108-961F-5A0CA69FDC91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAC8BF03-AFE4-4108-961F-5A0CA69FDC91}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -142,5 +165,9 @@ Global
 		{5EBC06E8-2BEF-44D2-8369-30E66EB107BD} = {25D7998E-82BA-4740-ADD5-86FF5A2E5B23}
 		{B923E1DA-5A49-4692-8AC9-A050ED657C69} = {5EBC06E8-2BEF-44D2-8369-30E66EB107BD}
 		{087E0A3C-3DE9-4D8A-8B1B-AA5DC7471A88} = {A8B84E74-4790-4D82-B810-CA54BF7E220B}
+		{EFA8175B-26B8-46DF-AE0C-C6669C5A47E6} = {91378479-4EF2-489D-AA0E-924E80D06C4C}
+		{B271804C-0B8F-404E-AC95-C5F21CD7E248} = {36DD66A8-5FD9-47A5-A0CC-0336493AAED2}
+		{AAC8BF03-AFE4-4108-961F-5A0CA69FDC91} = {EB0E8C89-DEB5-4DE7-9579-6EAD0C5430CE}
+		{37F031BF-EB4F-4D3A-8BA9-B25E82783ECB} = {A8B84E74-4790-4D82-B810-CA54BF7E220B}
 	EndGlobalSection
 EndGlobal

--- a/configuration.md
+++ b/configuration.md
@@ -1,10 +1,19 @@
 # Configuration based activators
 ## Global configuration
-The `GlobalConfigurationActivator` reads the status value of the `IFeature` from a `IConfigurationSection`.
+The `GlobalConfigurationActivator` reads the status value of the `IFeature` from an `IConfigurationSection`.
 The format of the configuration should be:
-
+```
+{
+    "App1": {
+        "Scope1": {
+            "Feature1": true,
+            "Feature2": false
+        }
+    }
+}
+```
 The outer section contains several application includ items, which include several scope items, which includes several feature items. Each feature value must be a boolean indicating if the feature is active or not.
 
-Any missing element (application, scope or feature) define the feature status as `NotSet`.
+Any missing element (application, scope or feature) defines the feature status as `NotSet`.
 
 

--- a/configuration.md
+++ b/configuration.md
@@ -1,0 +1,10 @@
+# Configuration based activators
+## Global configuration
+The `GlobalConfigurationActivator` reads the status value of the `IFeature` from a `IConfigurationSection`.
+The format of the configuration should be:
+
+The outer section contains several application includ items, which include several scope items, which includes several feature items. Each feature value must be a boolean indicating if the feature is active or not.
+
+Any missing element (application, scope or feature) define the feature status as `NotSet`.
+
+

--- a/samples/simplewebsite/SimpleWebSite/SimpleWebSite.csproj
+++ b/samples/simplewebsite/SimpleWebSite/SimpleWebSite.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
   </ItemGroup>
@@ -22,6 +24,7 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\di\MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration\MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration.csproj" />
     <ProjectReference Include="..\..\..\src\di\MAF.FeaturesFlipping.Extensions.DependencyInjection.EntityFrameworkCore\MAF.FeaturesFlipping.Extensions.DependencyInjection.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/samples/simplewebsite/SimpleWebSite/Startup.cs
+++ b/samples/simplewebsite/SimpleWebSite/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -10,11 +11,21 @@ namespace SimpleWebSite
 {
     public class Startup
     {
+
+        public IConfiguration Configuration { get; set; }
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+            Configuration = builder.Build();
+        }
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddFeaturesFlipping()
+                    .AddGlobalConfigurationActivator(Configuration.GetSection("Features"))
                 .AddSpecificEntityFrameworkCoreActivator<string>(_ => _.UseInMemoryDatabase(), "TenantId",
                     featureContext =>
                     {

--- a/samples/simplewebsite/SimpleWebSite/appsettings.json
+++ b/samples/simplewebsite/SimpleWebSite/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Features": {
+    "App1": {
+      "Scope1": {
+        "Feature1": true,
+        "Feature2": false
+      }
+    },
+    "App3": {
+      "ScopeC1": {
+        "FeatureC1a": true 
+      } 
+    } 
+  }
+}

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/AssemblyInfo.cs
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("MAF.FeaturesFlipping.Activators.Configuration.UnitTests")]

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeature.cs
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeature.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+using MAF.FeaturesFlipping.Extensibility.Activators;
+using Microsoft.Extensions.Configuration;
+
+namespace MAF.FeaturesFlipping.Activators.Configuration
+{
+    internal class GlobalConfigurationFeature : IFeature
+    {
+        private readonly IConfigurationSection _configurationSection;
+
+        public GlobalConfigurationFeature(IConfigurationSection configurationSection)
+        {
+            _configurationSection = configurationSection ??throw new ArgumentNullException(nameof(configurationSection));
+        }
+
+        public Task<FeatureActivationStatus> GetStatusAsync(IFeatureContext featureContext)
+        {
+            var value = _configurationSection.Value;
+            if (string.IsNullOrEmpty(value))
+            {
+                return Task.FromResult(FeatureActivationStatus.NotSet);
+            }
+
+            if (bool.TryParse(value, out var isActive))
+            {
+                if (isActive)
+                {
+                    return Task.FromResult(FeatureActivationStatus.Active);
+                }
+                return Task.FromResult(FeatureActivationStatus.Inactive);
+            }
+            return Task.FromResult(FeatureActivationStatus.NotSet);
+        }
+    }
+}

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeatureActivator.cs
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeatureActivator.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using MAF.FeaturesFlipping.Extensibility.Activators;
+using Microsoft.Extensions.Configuration;
+
+namespace MAF.FeaturesFlipping.Activators.Configuration
+{
+    public class GlobalConfigurationFeatureActivator : IFeatureActivator
+    {
+        private readonly IConfigurationSection _configurationSection;
+
+        public GlobalConfigurationFeatureActivator(IConfigurationSection configurationSection)
+        {
+            _configurationSection = configurationSection;
+        }
+
+        public Task<IFeature> GetFeatureAsync(IFeatureName featureName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeatureActivator.cs
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeatureActivator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using MAF.FeaturesFlipping.Extensibility.Activators;
 using Microsoft.Extensions.Configuration;
@@ -7,16 +6,20 @@ namespace MAF.FeaturesFlipping.Activators.Configuration
 {
     public class GlobalConfigurationFeatureActivator : IFeatureActivator
     {
-        private readonly IConfigurationSection _configurationSection;
+        private readonly IConfigurationSection _rootConfigurationSection;
 
-        public GlobalConfigurationFeatureActivator(IConfigurationSection configurationSection)
+        public GlobalConfigurationFeatureActivator(IConfigurationSection rootConfigurationSection)
         {
-            _configurationSection = configurationSection;
+            _rootConfigurationSection = rootConfigurationSection;
         }
 
         public Task<IFeature> GetFeatureAsync(IFeatureName featureName)
         {
-            throw new NotImplementedException();
+            var applicationSection = _rootConfigurationSection.GetSection(featureName.Application);
+            var scopeSection = applicationSection.GetSection(featureName.Scope);
+            var featureSection = scopeSection.GetSection(featureName.Feature);
+            var globalConfigurationFeature = new GlobalConfigurationFeature(featureSection);
+            return Task.FromResult<IFeature>(globalConfigurationFeature);
         }
     }
 }

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeatureActivator.cs
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/GlobalConfigurationFeatureActivator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using MAF.FeaturesFlipping.Extensibility.Activators;
 using Microsoft.Extensions.Configuration;
@@ -10,7 +11,7 @@ namespace MAF.FeaturesFlipping.Activators.Configuration
 
         public GlobalConfigurationFeatureActivator(IConfigurationSection rootConfigurationSection)
         {
-            _rootConfigurationSection = rootConfigurationSection;
+            _rootConfigurationSection = rootConfigurationSection ?? throw new ArgumentNullException(nameof(rootConfigurationSection));
         }
 
         public Task<IFeature> GetFeatureAsync(IFeatureName featureName)

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/MAF.FeaturesFlipping.Activators.Configuration.csproj
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/MAF.FeaturesFlipping.Activators.Configuration.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MAF.FeaturesFlipping.Extensibility.Activators.Abstractions\MAF.FeaturesFlipping.Extensibility.Activators.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/activators/MAF.FeaturesFlipping.Activators.Configuration/MAF.FeaturesFlipping.Activators.Configuration.csproj
+++ b/src/activators/MAF.FeaturesFlipping.Activators.Configuration/MAF.FeaturesFlipping.Activators.Configuration.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../MAF.FeaturesFlipping.CommonAssemblyInfo.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>

--- a/src/di/MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration/FeaturesFlippingBuilderGlobalConfigurationExtensions.cs
+++ b/src/di/MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration/FeaturesFlippingBuilderGlobalConfigurationExtensions.cs
@@ -1,0 +1,21 @@
+﻿using MAF.FeaturesFlipping.Activators.Configuration;
+using MAF.FeaturesFlipping.Extensibility.Activators;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace MAF.FeaturesFlipping.Extensions.DependencyInjection
+{
+    public static class FeaturesFlippingBuilderGlobalConfigurationExtensions
+    {
+        public static IFeaturesFlippingBuilder AddGlobalConfigurationActivator(
+            this IFeaturesFlippingBuilder featureFlippingBuilder,
+            IConfigurationSection configurationSection)
+        {
+            featureFlippingBuilder.Services.AddSingleton<IFeatureActivator>(
+                new GlobalConfigurationFeatureActivator(configurationSection));
+
+            return featureFlippingBuilder;
+        }
+    }
+}

--- a/src/di/MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration/MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration.csproj
+++ b/src/di/MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration/MAF.FeaturesFlipping.Extensions.DependencyInjection.Configuration.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\activators\MAF.FeaturesFlipping.Activators.Configuration\MAF.FeaturesFlipping.Activators.Configuration.csproj" />
+    <ProjectReference Include="..\MAF.FeaturesFlipping.Extensions.DependencyInjection\MAF.FeaturesFlipping.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MAF.FeaturesFlipping.UnitTests/MAF.FeaturesFlipping.UnitTests.csproj
+++ b/tests/MAF.FeaturesFlipping.UnitTests/MAF.FeaturesFlipping.UnitTests.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.7.63" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureActivatorTests.GetFeatureAsync.cs
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureActivatorTests.GetFeatureAsync.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using MAF.FeaturesFlipping.Extensibility.Activators;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Xunit;
+
+namespace MAF.FeaturesFlipping.Activators.Configuration.UnitTests
+{
+    public partial class GlobalConfigurationFeatureActivatorTests
+    {
+        [Trait("Category", "UnitTest")]
+        public class GetFeatureAsync
+        {
+            [Fact]
+            public void A_Non_Existing_Application_Returns_NotSet()
+            {
+                // Arrange
+                var memoryConfigurationSource = new MemoryConfigurationSource
+                {
+                    InitialData = new[] {new KeyValuePair<string, string>("SomePath", "")}
+                };
+                var memoryConfigurationProvider = new MemoryConfigurationProvider(memoryConfigurationSource);
+                var configurationRoot =
+                    new ConfigurationRoot(new List<IConfigurationProvider> {memoryConfigurationProvider});
+                var configurationSection = new ConfigurationSection(configurationRoot, "somePath");
+                var featureActivator = new GlobalConfigurationFeatureActivator(configurationSection);
+
+                // Act
+                var actualFeature = featureActivator.GetFeatureAsync(new FeatureName("App1", "Scope1", "Feature1"))
+                    .Result;
+
+                // Assert
+                var actual = actualFeature.GetStatusAsync(null).Result;
+                Assert.Equal(FeatureActivationStatus.NotSet, actual);
+            }
+        }
+    }
+}

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureActivatorTests.cs
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureActivatorTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MAF.FeaturesFlipping.Activators.Configuration.UnitTests
+{
+    [Trait("Category", "UnitTest")]
+    public partial class GlobalConfigurationFeatureActivatorTests
+    {
+        [Fact]
+        public void A_NotNull_ConfigurationSection_Do_Not_Throw_An_Exception()
+        {
+            // Arrange
+            var configurationSection = new ConfigurationSection(
+                new ConfigurationRoot(
+                    new List<IConfigurationProvider>()),
+                "somePath");
+            // Act & Assert
+            var feature = new GlobalConfigurationFeatureActivator(configurationSection);
+            Assert.NotNull(feature);
+        }
+
+        [Fact]
+        public void A_Null_ConfigurationSection_Throw_A_ArgumentNullException()
+        {
+            // Arrange
+            var expectedParamName = "rootConfigurationSection";
+
+            // Act & Assert
+            var actual = Assert.Throws<ArgumentNullException>(() => new GlobalConfigurationFeatureActivator(null));
+            Assert.Equal(expectedParamName, actual.ParamName);
+        }
+    }
+}

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureTests.GetStatusAsync.cs
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureTests.GetStatusAsync.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using MAF.FeaturesFlipping.Extensibility.Activators;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Xunit;
+
+namespace MAF.FeaturesFlipping.Activators.Configuration.UnitTests
+{
+    public partial class GlobalConfigurationFeatureTests
+    {
+        [Trait("Category", "UnitTest")]
+        public class GetStatusAsync
+        {
+            [Theory]
+            [InlineData(null, FeatureActivationStatus.NotSet)]
+            [InlineData("", FeatureActivationStatus.NotSet)]
+            [InlineData("true", FeatureActivationStatus.Active)]
+            [InlineData("false", FeatureActivationStatus.Inactive)]
+            [InlineData("value", FeatureActivationStatus.NotSet)]
+            public void Read_Of_The_Configuration_Section_Returns_The_Correct_Status(string configurationSectionValue,
+                FeatureActivationStatus expectedFeatureActivationStatus)
+            {
+                // Arrange
+                var memoryConfigurationSource = new MemoryConfigurationSource
+                {
+                    InitialData = new[] {new KeyValuePair<string, string>("SomePath", configurationSectionValue) }
+                };
+                var memoryConfigurationProvider = new MemoryConfigurationProvider(memoryConfigurationSource);
+                var configurationRoot = new ConfigurationRoot(new List<IConfigurationProvider> { memoryConfigurationProvider });
+                var configurationSection = new ConfigurationSection(configurationRoot, "somePath");
+                var feature = new GlobalConfigurationFeature(configurationSection);
+
+                // Act
+                var actual = feature.GetStatusAsync(null).Result;
+
+                // Assert
+                Assert.Equal(expectedFeatureActivationStatus, actual);
+            }
+        }
+    }
+}

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureTests.cs
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/GlobalConfigurationFeatureTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MAF.FeaturesFlipping.Activators.Configuration.UnitTests
+{
+    [Trait("Category", "UnitTest")]
+    public partial class GlobalConfigurationFeatureTests
+    {
+        [Fact]
+        public void A_Null_ConfigurationSection_Throw_A_ArgumentNullException()
+        {
+            // Arrange
+            var expectedParamName = "configurationSection";
+
+            // Act & Assert
+            var actual = Assert.Throws<ArgumentNullException>(() => new GlobalConfigurationFeature(null));
+            Assert.Equal(expectedParamName, actual.ParamName);
+        }
+        [Fact]
+        public void A_NotNull_ConfigurationSection_Do_Not_Throw_An_Exception()
+        {
+            // Arrange
+            var configurationSection = new ConfigurationSection(
+                new ConfigurationRoot(
+                    new List<IConfigurationProvider>()),
+                "somePath");
+            // Act & Assert
+            var feature = new GlobalConfigurationFeature(configurationSection);
+            Assert.NotNull(feature);
+        }
+    }
+}

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj
@@ -1,11 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\activators\MAF.FeaturesFlipping.Activators.Configuration\MAF.FeaturesFlipping.Activators.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Configuration">
+      <HintPath>..\..\..\..\..\..\Users\mgrosperrin\.nuget\packages\microsoft.extensions.configuration\1.1.2\lib\netstandard1.1\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\activators\MAF.FeaturesFlipping.Activators.Configuration\MAF.FeaturesFlipping.Activators.Configuration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.Configuration.UnitTests/MAF.FeaturesFlipping.Activators.Configuration.UnitTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
@@ -12,12 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\activators\MAF.FeaturesFlipping.Activators.Configuration\MAF.FeaturesFlipping.Activators.Configuration.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Configuration">
-      <HintPath>..\..\..\..\..\..\Users\mgrosperrin\.nuget\packages\microsoft.extensions.configuration\1.1.2\lib\netstandard1.1\Microsoft.Extensions.Configuration.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\..\src\MAF.FeaturesFlipping\MAF.FeaturesFlipping.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/activators/MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests/MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.csproj
+++ b/tests/activators/MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests/MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/di/MAF.FeaturesFlipping.Extensions.DependencyInjection.UnitTests/MAF.FeaturesFlipping.Extensions.DependencyInjection.UnitTests.csproj
+++ b/tests/di/MAF.FeaturesFlipping.Extensions.DependencyInjection.UnitTests/MAF.FeaturesFlipping.Extensions.DependencyInjection.UnitTests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Moq" Version="4.7.63" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 


### PR DESCRIPTION
The activator is based on `Microsoft.Extensions.Configuration.IConfigurationSection`.
Currently, the only activator is global and doesn't depends on the context.
It fixes #2 