### PR TITLE
Rename FeatureName to FeatureSpec

### DIFF
--- a/docs/activators/configuration.md
+++ b/docs/activators/configuration.md
@@ -6,14 +6,14 @@ The format of the configuration should be:
 {
     "App1": {
         "Scope1": {
-            "Feature1": true,
-            "Feature2": false
+            "FeatureName1": true,
+            "FeatureName2": false
         }
     }
 }
 ```
 The outer section contains several application includ items, which include several scope items, which includes several feature items. Each feature value must be a boolean indicating if the feature is active or not.
 
-Any missing element (application, scope or feature) defines the feature status as `NotSet`.
+Any missing element (application, scope or feature name) defines the feature status as `NotSet`.
 
 

--- a/docs/aspnet/feature-tag-helper.md
+++ b/docs/aspnet/feature-tag-helper.md
@@ -2,5 +2,5 @@
 ## ASP.NET Core
 ### Tag helper
 
-The Feature Tag Helper conditionally renders its enclosed content based on the activation status of the specified feature. The feature can be specified via its `feature` attribute (given a `FeatureName`), or `application`, `scope` and `feature-name` properties which will build the corresponding `FeatureName`.
+The Feature Tag Helper conditionally renders its enclosed content based on the activation status of the specified feature. The feature can be specified via its `feature-spec` attribute (given a `FeatureSpec`), or `application`, `scope` and `feature-name` properties which will build the corresponding `FeatureSpec`.
 The Feature Tag Helper can also be used to render content when the feature is inactive thanks to the `inverse` attribute.

--- a/samples/simplewebsite/SimpleWebSite/Startup.cs
+++ b/samples/simplewebsite/SimpleWebSite/Startup.cs
@@ -53,7 +53,7 @@ namespace SimpleWebSite
             app.Run(async context =>
             {
                 var featureService = context.RequestServices.GetService<IFeatureService>();
-                if (await featureService.IsFeatureActiveAsync(new FeatureName("", "", "")))
+                if (await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")))
                 {
                     await context.Response.WriteAsync("Hello World!");
                 }

--- a/samples/simplewebsite/SimpleWebSite/Views/Home/Index.cshtml
+++ b/samples/simplewebsite/SimpleWebSite/Views/Home/Index.cshtml
@@ -1,12 +1,12 @@
 ﻿@using MAF.FeaturesFlipping
 @{
-    var feature = new FeatureName("App1", "Scope1", "Feature1");
+    var featureSpec = new FeatureSpec("App1", "Scope1", "Feature1");
 }
 <div>
     <feature application="App1" scope="Scope1" feature-name="Feature1">
         <p>App1;Scope;Feature</p>
     </feature> 
-    <feature feature="feature" inverse="true">
+    <feature feature-spec="featureSpec" inverse="true">
         <p>not(App1;Scope1;Feature1)</p>
     </feature> 
 </div>

--- a/src/MAF.FeaturesFlipping.Abstractions/FeatureSpec.cs
+++ b/src/MAF.FeaturesFlipping.Abstractions/FeatureSpec.cs
@@ -2,24 +2,24 @@
 
 namespace MAF.FeaturesFlipping
 {
-    public struct FeatureName
+    public struct FeatureSpec
     {
         private readonly string _application;
         private readonly string _scope;
-        private readonly string _feature;
+        private readonly string _featureName;
 
-        public FeatureName(string application, string scope, string feature)
+        public FeatureSpec(string application, string scope, string featureName)
         {
             _application = application;
             _scope = scope;
-            _feature = feature;
+            _featureName = featureName;
         }
 
         public string Application => _application ?? string.Empty;
 
         public string Scope => _scope ?? string.Empty;
 
-        public string Feature => _feature ?? string.Empty;
+        public string FeatureName => _featureName ?? string.Empty;
 
         public override int GetHashCode()
         {
@@ -28,22 +28,22 @@ namespace MAF.FeaturesFlipping
                 int hash = 17;
                 hash = hash * 23 + Application.GetHashCode();
                 hash = hash * 23 + Scope.GetHashCode();
-                hash = hash * 23 + Feature.GetHashCode();
+                hash = hash * 23 + FeatureName.GetHashCode();
                 return hash;
             }
         }
 
         public override bool Equals(object obj)
         {
-            return obj is FeatureName featureName
-                   && Application.Equals(featureName.Application, StringComparison.CurrentCulture)
-                   && Scope.Equals(featureName.Scope, StringComparison.CurrentCulture)
-                   && Feature.Equals(featureName.Feature, StringComparison.CurrentCulture);
+            return obj is FeatureSpec featureSpec
+                   && Application.Equals(featureSpec.Application, StringComparison.CurrentCulture)
+                   && Scope.Equals(featureSpec.Scope, StringComparison.CurrentCulture)
+                   && FeatureName.Equals(featureSpec.FeatureName, StringComparison.CurrentCulture);
         }
 
         public override string ToString()
         {
-            return $"<Application={Application};Scope={Scope};Feature={Feature}>";
+            return $"<Application={Application};Scope={Scope};FeatureName={FeatureName}>";
         }
     }
 }

--- a/src/MAF.FeaturesFlipping.Abstractions/IFeatureService.cs
+++ b/src/MAF.FeaturesFlipping.Abstractions/IFeatureService.cs
@@ -4,6 +4,6 @@ namespace MAF.FeaturesFlipping
 {
     public interface IFeatureService
     {
-        Task<bool> IsFeatureActiveAsync(FeatureName featureName);
+        Task<bool> IsFeatureActiveAsync(FeatureSpec featureSpec);
     }
 }

--- a/src/MAF.FeaturesFlipping.Extensibility.Activators.Abstractions/IFeatureActivator.cs
+++ b/src/MAF.FeaturesFlipping.Extensibility.Activators.Abstractions/IFeatureActivator.cs
@@ -4,6 +4,6 @@ namespace MAF.FeaturesFlipping.Extensibility.Activators
 {
     public interface IFeatureActivator
     {
-        Task<IFeature> GetFeatureAsync(FeatureName featureName);
+        Task<IFeature> GetFeatureAsync(FeatureSpec featureSpec);
     }
 }

--- a/src/MAF.FeaturesFlipping/FeatureService.cs
+++ b/src/MAF.FeaturesFlipping/FeatureService.cs
@@ -6,8 +6,8 @@ namespace MAF.FeaturesFlipping
 {
     public sealed class FeatureService : IFeatureService
     {
-        private readonly Dictionary<FeatureName, bool> _featureActivationResultCache =
-            new Dictionary<FeatureName, bool>();
+        private readonly Dictionary<FeatureSpec, bool> _featureActivationResultCache =
+            new Dictionary<FeatureSpec, bool>();
         private readonly IEnumerable<IFeatureActivator> _featureActivators;
         private readonly IFeatureContextAccessor _featureContextAccessor;
 
@@ -18,17 +18,17 @@ namespace MAF.FeaturesFlipping
             _featureContextAccessor = featureContextAccessor;
         }
 
-        public async Task<bool> IsFeatureActiveAsync(FeatureName featureName)
+        public async Task<bool> IsFeatureActiveAsync(FeatureSpec featureSpec)
         {
-            if (!_featureActivationResultCache.ContainsKey(featureName))
+            if (!_featureActivationResultCache.ContainsKey(featureSpec))
             {
-                var isFeatureActive = await ComputeIsFeatureActiveAsync(featureName);
-                _featureActivationResultCache.Add(featureName, isFeatureActive);
+                var isFeatureActive = await ComputeIsFeatureActiveAsync(featureSpec);
+                _featureActivationResultCache.Add(featureSpec, isFeatureActive);
             }
-            return _featureActivationResultCache.TryGetValue(featureName, out var result) && result;
+            return _featureActivationResultCache.TryGetValue(featureSpec, out var result) && result;
         }
 
-        private async Task<bool> ComputeIsFeatureActiveAsync(FeatureName featureName)
+        private async Task<bool> ComputeIsFeatureActiveAsync(FeatureSpec featureSpec)
         {
             var featureContext = _featureContextAccessor.GetCurrentFeatureContext();
             var isFeatureActive = false;
@@ -36,7 +36,7 @@ namespace MAF.FeaturesFlipping
             {
                 foreach (var featureActivator in _featureActivators)
                 {
-                    var feature = await featureActivator.GetFeatureAsync(featureName) ?? NotSetFeature.Instance;
+                    var feature = await featureActivator.GetFeatureAsync(featureSpec) ?? NotSetFeature.Instance;
                     var featureActivationStatus = await feature.GetStatusAsync(featureContext);
                     switch (featureActivationStatus)
                     {

--- a/src/activators/configuration/GlobalConfigurationFeatureActivator.cs
+++ b/src/activators/configuration/GlobalConfigurationFeatureActivator.cs
@@ -15,11 +15,11 @@ namespace MAF.FeaturesFlipping.Activators.Configuration
 
         internal IConfigurationSection ConfigurationSection { get; }
 
-        public Task<IFeature> GetFeatureAsync(FeatureName featureName)
+        public Task<IFeature> GetFeatureAsync(FeatureSpec featureSpec)
         {
-            var applicationSection = ConfigurationSection.GetSection(featureName.Application);
-            var scopeSection = applicationSection.GetSection(featureName.Scope);
-            var featureSection = scopeSection.GetSection(featureName.Feature);
+            var applicationSection = ConfigurationSection.GetSection(featureSpec.Application);
+            var scopeSection = applicationSection.GetSection(featureSpec.Scope);
+            var featureSection = scopeSection.GetSection(featureSpec.FeatureName);
             var globalConfigurationFeature = new GlobalConfigurationFeature(featureSection);
             return Task.FromResult<IFeature>(globalConfigurationFeature);
         }

--- a/src/activators/efcore/Global/GlobalDbContextConfiguration.cs
+++ b/src/activators/efcore/Global/GlobalDbContextConfiguration.cs
@@ -7,7 +7,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Global
     {
         private readonly Action<DbContextOptionsBuilder> _dbContextBuilderAction;
         private string _applicationColumnName;
-        private string _featureColumnName;
+        private string _featureNameColumnName;
         private string _isActiveColumnName;
         private string _schema;
         private string _scopeColumnName;
@@ -19,7 +19,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Global
                 .TableName("GlobalFeature")
                 .ApplicationColumnName("Application")
                 .ScopeColumnName("Scope")
-                .FeatureColumnName("Feature")
+                .FeatureNameColumnName("FeatureName")
                 .IsActiveColumnName("IsActive");
             _dbContextBuilderAction = dbContextBuilderAction ?? (_ => { });
         }
@@ -77,16 +77,16 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Global
             return this;
         }
 
-        public string FeatureColumnName()
+        public string FeatureNameColumnName()
         {
-            return _featureColumnName;
+            return _featureNameColumnName;
         }
 
-        public GlobalDbContextConfiguration FeatureColumnName(string featureColumnName)
+        public GlobalDbContextConfiguration FeatureNameColumnName(string featureNameColumnName)
         {
-            if (!string.IsNullOrWhiteSpace(featureColumnName))
+            if (!string.IsNullOrWhiteSpace(featureNameColumnName))
             {
-                _featureColumnName = featureColumnName;
+                _featureNameColumnName = featureNameColumnName;
             }
             return this;
         }

--- a/src/activators/efcore/Global/GlobalEntityFrameworkCoreActivator.cs
+++ b/src/activators/efcore/Global/GlobalEntityFrameworkCoreActivator.cs
@@ -13,11 +13,11 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Global
             _globalFeatureDbContext = globalFeatureDbContext;
         }
 
-        public async Task<IFeature> GetFeatureAsync(FeatureName featureName)
+        public async Task<IFeature> GetFeatureAsync(FeatureSpec featureSpec)
         {
             var globalFeatureEntity = await _globalFeatureDbContext.Features.FirstOrDefaultAsync(
-                feature => feature.Application == featureName.Application && feature.Scope ==
-                           featureName.Scope && feature.Feature == featureName.Feature);
+                feature => feature.Application == featureSpec.Application && feature.Scope ==
+                           featureSpec.Scope && feature.FeatureName == featureSpec.FeatureName);
             var featureFromEntity = new FeatureFromEntity(globalFeatureEntity);
             return featureFromEntity;
         }

--- a/src/activators/efcore/Global/GlobalFeatureDbContext.cs
+++ b/src/activators/efcore/Global/GlobalFeatureDbContext.cs
@@ -32,8 +32,8 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Global
                 .IsRequired().HasColumnName(_globalDbContextConfigurer.ApplicationColumnName());
             featureEntityModelBuilder.Property(_ => _.Scope)
                 .IsRequired().HasColumnName(_globalDbContextConfigurer.ScopeColumnName());
-            featureEntityModelBuilder.Property(_ => _.Feature)
-                .IsRequired().HasColumnName(_globalDbContextConfigurer.FeatureColumnName());
+            featureEntityModelBuilder.Property(_ => _.FeatureName)
+                .IsRequired().HasColumnName(_globalDbContextConfigurer.FeatureNameColumnName());
             featureEntityModelBuilder.Property(_ => _.IsActive)
                 .HasColumnName(_globalDbContextConfigurer.IsActiveColumnName());
         }

--- a/src/activators/efcore/Global/GlobalFeatureEntity.cs
+++ b/src/activators/efcore/Global/GlobalFeatureEntity.cs
@@ -5,7 +5,7 @@
         public int FeatureId { get; set; }
         public string Application { get; set; }
         public string Scope { get; set; }
-        public string Feature { get; set; }
+        public string FeatureName { get; set; }
         public bool? IsActive { get; set; }
     }
 }

--- a/src/activators/efcore/IFeatureEntity.cs
+++ b/src/activators/efcore/IFeatureEntity.cs
@@ -4,7 +4,7 @@
     {
         string Application { get; set; }
         string Scope { get; set; }
-        string Feature { get; set; }
+        string FeatureName { get; set; }
         bool? IsActive { get; set; }
     }
 }

--- a/src/activators/efcore/Specific/SpecificDbContextConfiguration.cs
+++ b/src/activators/efcore/Specific/SpecificDbContextConfiguration.cs
@@ -13,7 +13,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Specific
             _specificFeatureFilterWithContext;
 
         private string _applicationColumnName;
-        private string _featureColumnName;
+        private string _featureNameColumnName;
         private string _isActiveColumnName;
         private string _otherColumnName;
         private string _schema;
@@ -32,7 +32,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Specific
                 .TableName("SpecificFeature")
                 .ApplicationColumnName("Application")
                 .ScopeColumnName("Scope")
-                .FeatureColumnName("Feature")
+                .FeatureNameColumnName("FeatureName")
                 .IsActiveColumnName("IsActive")
                 .OtherColumnName(otherColumnName);
             _dbContextBuilderAction = dbContextBuilderAction ?? (_ => { });
@@ -91,16 +91,16 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Specific
             return this;
         }
 
-        public string FeatureColumnName()
+        public string FeatureNameColumnName()
         {
-            return _featureColumnName;
+            return _featureNameColumnName;
         }
 
-        public SpecificDbContextConfiguration<TOtherColumn> FeatureColumnName(string featureColumnName)
+        public SpecificDbContextConfiguration<TOtherColumn> FeatureNameColumnName(string featureNameColumnName)
         {
-            if (!string.IsNullOrWhiteSpace(featureColumnName))
+            if (!string.IsNullOrWhiteSpace(featureNameColumnName))
             {
-                _featureColumnName = featureColumnName;
+                _featureNameColumnName = featureNameColumnName;
             }
             return this;
         }

--- a/src/activators/efcore/Specific/SpecificEntityFrameworkCoreActivator.cs
+++ b/src/activators/efcore/Specific/SpecificEntityFrameworkCoreActivator.cs
@@ -13,12 +13,12 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Specific
             _specificFeatureDbContext = specificFeatureDbContext;
         }
 
-        public Task<IFeature> GetFeatureAsync(FeatureName featureName)
+        public Task<IFeature> GetFeatureAsync(FeatureSpec featureSpec)
         {
             var specificFeatureQuery = _specificFeatureDbContext.Features.Where(
-                feature => feature.Application == featureName.Application
-                               && feature.Scope == featureName.Scope
-                               && feature.Feature == featureName.Feature);
+                feature => feature.Application == featureSpec.Application
+                               && feature.Scope == featureSpec.Scope
+                               && feature.FeatureName == featureSpec.FeatureName);
             
             var specificFeature = new SpecificFeature<TOtherColumn>(specificFeatureQuery, _specificFeatureDbContext.SpecificConfiguration);
             return Task.FromResult<IFeature>(specificFeature);

--- a/src/activators/efcore/Specific/SpecificFeatureDbContext.cs
+++ b/src/activators/efcore/Specific/SpecificFeatureDbContext.cs
@@ -33,8 +33,8 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.Specific
                 .IsRequired().HasColumnName(_specificDbContextConfigurer.ApplicationColumnName());
             featureEntityModelBuilder.Property(_ => _.Scope)
                 .IsRequired().HasColumnName(_specificDbContextConfigurer.ScopeColumnName());
-            featureEntityModelBuilder.Property(_ => _.Feature)
-                .IsRequired().HasColumnName(_specificDbContextConfigurer.FeatureColumnName());
+            featureEntityModelBuilder.Property(_ => _.FeatureName)
+                .IsRequired().HasColumnName(_specificDbContextConfigurer.FeatureNameColumnName());
             featureEntityModelBuilder.Property(_ => _.IsActive)
                 .HasColumnName(_specificDbContextConfigurer.IsActiveColumnName());
             featureEntityModelBuilder.Property(_ => _.OtherColumn)

--- a/src/activators/efcore/Specific/SpecificFeatureEntity.cs
+++ b/src/activators/efcore/Specific/SpecificFeatureEntity.cs
@@ -5,7 +5,7 @@
         public int FeatureId { get; set; }
         public string Application { get; set; }
         public string Scope { get; set; }
-        public string Feature { get; set; }
+        public string FeatureName { get; set; }
         public bool? IsActive { get; set; }
         public TOtherColumn OtherColumn { get; set; }
     }

--- a/src/aspnet/aspnetcore/FeatureFilterAttribute.cs
+++ b/src/aspnet/aspnetcore/FeatureFilterAttribute.cs
@@ -10,19 +10,19 @@ namespace MAF.FeaturesFlipping.AspNetCore
     {
         public string Application { get; }
         public string Scope { get; }
-        public string Feature { get; }
+        public string FeatureName { get; }
 
-        public FeatureFilterAttribute(string application, string scope, string feature)
+        public FeatureFilterAttribute(string application, string scope, string featureName)
         {
             Application = application;
             Scope = scope;
-            Feature = feature;
+            FeatureName = featureName;
         }
 
         public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
         {
             var featureService = serviceProvider.GetRequiredService<IFeatureService>();
-            return new FeatureResourceFilter(featureService, new FeatureName(Application, Scope, Feature));
+            return new FeatureResourceFilter(featureService, new FeatureSpec(Application, Scope, FeatureName));
         }
 
         public bool IsReusable => false;
@@ -30,17 +30,17 @@ namespace MAF.FeaturesFlipping.AspNetCore
         private class FeatureResourceFilter : IAsyncResourceFilter
         {
             private readonly IFeatureService _featureService;
-            private readonly FeatureName _featureName;
+            private readonly FeatureSpec _featureSpec;
 
-            public FeatureResourceFilter(IFeatureService featureService, FeatureName featureName)
+            public FeatureResourceFilter(IFeatureService featureService, FeatureSpec featureSpec)
             {
                 _featureService = featureService ?? throw new ArgumentNullException(nameof(featureService));
-                _featureName = featureName;
+                _featureSpec = featureSpec;
             }
 
             public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
             {
-                if (!await _featureService.IsFeatureActiveAsync(_featureName))
+                if (!await _featureService.IsFeatureActiveAsync(_featureSpec))
                 {
                     context.Result = new NotFoundResult();
                 }

--- a/src/aspnet/aspnetcore/FeatureTagHelper.cs
+++ b/src/aspnet/aspnetcore/FeatureTagHelper.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace MAF.FeaturesFlipping.AspNetCore
 {
-    [HtmlTargetElement(FeatureTagName, Attributes = FeatureAttributeName)]
+    [HtmlTargetElement(FeatureTagName, Attributes = FeatureSpecAttributeName)]
     [HtmlTargetElement(FeatureTagName, Attributes = ApplicationAttributeName)]
     [HtmlTargetElement(FeatureTagName, Attributes = ScopeAttributeName)]
     [HtmlTargetElement(FeatureTagName, Attributes = FeatureNameAttributeName)]
@@ -15,9 +15,9 @@ namespace MAF.FeaturesFlipping.AspNetCore
 
         private const string FeatureTagName = "feature";
 
-        private const string FeatureAttributeName = "feature";
-        [HtmlAttributeName(FeatureAttributeName)]
-        public FeatureName Feature { get; set; }
+        private const string FeatureSpecAttributeName = "feature-spec";
+        [HtmlAttributeName(FeatureSpecAttributeName)]
+        public FeatureSpec FeatureSpec { get; set; }
 
         private const string ApplicationAttributeName = "application";
         [HtmlAttributeName(ApplicationAttributeName)]
@@ -54,8 +54,8 @@ namespace MAF.FeaturesFlipping.AspNetCore
             
             output.TagName = null;
 
-            var featureName = GetFeatureToEvaluate();
-            var isFeatureActive = await _featureService.IsFeatureActiveAsync(featureName);
+            var featureSpec = GetFeatureSpecToEvaluate();
+            var isFeatureActive = await _featureService.IsFeatureActiveAsync(featureSpec);
             var suppressOutput = ShouldSuppressOutput(isFeatureActive);
 
             if (suppressOutput)
@@ -69,12 +69,12 @@ namespace MAF.FeaturesFlipping.AspNetCore
             return !(isFeatureActive ^ Inverse);
         }
 
-        internal FeatureName GetFeatureToEvaluate()
+        internal FeatureSpec GetFeatureSpecToEvaluate()
         {
-            var featureName = Feature.Equals(default(FeatureName))
-                ? new FeatureName(Application, Scope, FeatureName)
-                : Feature;
-            return featureName;
+            var featureSpec = FeatureSpec.Equals(default(FeatureSpec))
+                ? new FeatureSpec(Application, Scope, FeatureName)
+                : FeatureSpec;
+            return featureSpec;
         }
     }
 }

--- a/tests/MAF.FeaturesFlipping.UnitTests/FeatureServiceTests.IsFeatureActiveAsync.cs
+++ b/tests/MAF.FeaturesFlipping.UnitTests/FeatureServiceTests.IsFeatureActiveAsync.cs
@@ -23,11 +23,11 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Inactive);
                 var featureActivatorInactiveMock = new Mock<IFeatureActivator>();
                 featureActivatorInactiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(inactiveFeatureMock.Object);
                 var featureActivatorNeverCalledMock = new Mock<IFeatureActivator>();
                 featureActivatorNeverCalledMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .Verifiable("hould never be called after inactive");
 
                 var featureService = new FeatureService(
@@ -35,11 +35,11 @@ namespace MAF.FeaturesFlipping.UnitTests
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.False(actual);
-                featureActivatorNeverCalledMock.Verify(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()), Times.Never);
+                featureActivatorNeverCalledMock.Verify(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()), Times.Never);
             }
             [Fact]
             public void Returns_False_When_Features_Are_Inactive_NotSet_Active()
@@ -54,7 +54,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Inactive);
                 var featureActivatorInactiveMock = new Mock<IFeatureActivator>();
                 featureActivatorInactiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(inactiveFeatureMock.Object);
 
                 var notSetFeatureMock = new Mock<IFeature>();
@@ -62,7 +62,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.NotSet);
                 var featureActivatorNotSetMock = new Mock<IFeatureActivator>();
                 featureActivatorNotSetMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(notSetFeatureMock.Object);
 
                 var activeFeatureMock = new Mock<IFeature>();
@@ -70,7 +70,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Active);
                 var featureActivatorActiveMock = new Mock<IFeatureActivator>();
                 featureActivatorActiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(activeFeatureMock.Object);
 
                 var featureService = new FeatureService(
@@ -82,7 +82,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.False(actual);
@@ -98,7 +98,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.False(actual);
@@ -112,13 +112,13 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .Returns(() => null);
                 var featureActivatorMock = new Mock<IFeatureActivator>();
                 featureActivatorMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(() => null);
                 var featureService = new FeatureService(Enumerable.Repeat(featureActivatorMock.Object, 2),
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.False(actual);
@@ -136,7 +136,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Active);
                 var featureActivatorActiveMock = new Mock<IFeatureActivator>();
                 featureActivatorActiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(activeFeatureMock.Object);
 
                 var featureService = new FeatureService(
@@ -147,7 +147,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.True(actual);
@@ -165,7 +165,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Active);
                 var featureActivatorActiveMock = new Mock<IFeatureActivator>();
                 featureActivatorActiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(activeFeatureMock.Object);
 
                 var notSetFeatureMock = new Mock<IFeature>();
@@ -173,7 +173,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.NotSet);
                 var featureActivatorNotSetMock = new Mock<IFeatureActivator>();
                 featureActivatorNotSetMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(notSetFeatureMock.Object);
 
                 var featureService = new FeatureService(
@@ -185,7 +185,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.True(actual);
@@ -203,7 +203,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Active);
                 var featureActivatorActiveMock = new Mock<IFeatureActivator>();
                 featureActivatorActiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(activeFeatureMock.Object);
 
                 var notSetFeatureMock = new Mock<IFeature>();
@@ -211,7 +211,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.NotSet);
                 var featureActivatorNotSetMock = new Mock<IFeatureActivator>();
                 featureActivatorNotSetMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(notSetFeatureMock.Object);
 
                 var featureService = new FeatureService(
@@ -223,7 +223,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     featureContextAccessorMock.Object);
 
                 // Act
-                var actual = featureService.IsFeatureActiveAsync(new FeatureName("", "", "")).Result;
+                var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
 
                 // Assert
                 Assert.True(actual);
@@ -246,7 +246,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.NotSet);
                 var featureActivatorNotSetMock = new Mock<IFeatureActivator>();
                 featureActivatorNotSetMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(notSetFeatureMock.Object);
 
                 var activeFeatureMock = new Mock<IFeature>();
@@ -254,7 +254,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(FeatureActivationStatus.Active);
                 var featureActivatorActiveMock = new Mock<IFeatureActivator>();
                 featureActivatorActiveMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(activeFeatureMock.Object);
                 var featureService = new FeatureService(
                     new[]
@@ -264,7 +264,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     }, featureContextAccessorMock.Object);
 
                 // Act
-                var actual = await featureService.IsFeatureActiveAsync(new FeatureName("", "", ""));
+                var actual = await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", ""));
 
                 // Assert
                 Assert.True(actual);
@@ -294,7 +294,7 @@ namespace MAF.FeaturesFlipping.UnitTests
                     .ReturnsAsync(featureActivationStatus);
                 var featureActivatorMock = new Mock<IFeatureActivator>();
                 featureActivatorMock
-                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()))
+                    .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(featureMock.Object);
                 var featureService = new FeatureService(
                     new[]
@@ -303,8 +303,8 @@ namespace MAF.FeaturesFlipping.UnitTests
                     }, featureContextAccessorMock.Object);
 
                 // Act
-                var actual = await featureService.IsFeatureActiveAsync(new FeatureName("", "", ""));
-                var actual2 = await featureService.IsFeatureActiveAsync(new FeatureName("", "", ""));
+                var actual = await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", ""));
+                var actual2 = await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", ""));
 
                 // Assert
                 Assert.Equal(expected, actual);
@@ -312,7 +312,7 @@ namespace MAF.FeaturesFlipping.UnitTests
 
                 featureContextAccessorMock.Verify(_ => _.GetCurrentFeatureContext(), Times.Once);
                 featureContextAccessorMock.Verify(_ => _.DisposeFeatureContext(featureContextMock.Object), Times.Once);
-                featureActivatorMock.Verify(_ => _.GetFeatureAsync(It.IsAny<FeatureName>()), Times.Once);
+                featureActivatorMock.Verify(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()), Times.Once);
             }
         }
     }

--- a/tests/MAF.FeaturesFlipping.UnitTests/FeatureSpecTests.cs
+++ b/tests/MAF.FeaturesFlipping.UnitTests/FeatureSpecTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace MAF.FeaturesFlipping.UnitTests
 {
     [Trait("Category", "UnitTest")]
-    public class FeatureNameTests
+    public class FeatureSpecTests
     {
         [Fact]
         public void The_Constructor_Correctly_Sets_The_Properties()
@@ -15,12 +15,12 @@ namespace MAF.FeaturesFlipping.UnitTests
             var expectedFeature = "Feature" + Guid.NewGuid();
 
             // Act
-            var actual = new FeatureName(expectedApplication, expectedScope, expectedFeature);
+            var actual = new FeatureSpec(expectedApplication, expectedScope, expectedFeature);
 
             // Assert
             Assert.Equal(expectedApplication, actual.Application);
             Assert.Equal(expectedScope, actual.Scope);
-            Assert.Equal(expectedFeature, actual.Feature);
+            Assert.Equal(expectedFeature, actual.FeatureName);
         }
     }
 }

--- a/tests/activators/configuration/GlobalConfigurationFeatureActivatorTests.GetFeatureAsync.cs
+++ b/tests/activators/configuration/GlobalConfigurationFeatureActivatorTests.GetFeatureAsync.cs
@@ -26,7 +26,7 @@ namespace MAF.FeaturesFlipping.Activators.Configuration.UnitTests
                 var featureActivator = new GlobalConfigurationFeatureActivator(configurationSection);
 
                 // Act
-                var actualFeature = featureActivator.GetFeatureAsync(new FeatureName("App1", "Scope1", "Feature1"))
+                var actualFeature = featureActivator.GetFeatureAsync(new FeatureSpec("App1", "Scope1", "Feature1"))
                     .Result;
 
                 // Assert

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.ApplicationColumnName.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.ApplicationColumnName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "NewApplicationColumn";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.FeatureColumnName.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.FeatureColumnName.cs
@@ -6,77 +6,77 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
     public partial class GlobalDbContextConfigurationTests
     {
         [Trait("Category", "UnitTest")]
-        public class FeatureColumnName
+        public class FeatureNameColumnName
         {
             [Fact]
-            public void Calling_FeatureColumnName_With_A_New_Name_Changes_The_FeatureColumnName()
+            public void Calling_FeatureNameColumnName_With_A_New_Name_Changes_The_FeatureNameColumnName()
             {
                 // Arrange
                 var expectedSchema = "Feature";
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "NewFeatureColumn";
+                var expectedFeatureNameColumnName = "NewFeatureColumn";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
                 // Act
-                actual.FeatureColumnName(expectedFeatureColumnName);
+                actual.FeatureNameColumnName(expectedFeatureNameColumnName);
 
                 // Assert
                 Assert.Equal(expectedSchema, actual.Schema());
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
             [Fact]
-            public void Calling_FeatureColumnName_With_A_Null_Doesnt_Change_The_FeatureColumnName()
+            public void Calling_FeatureNameColumnName_With_A_Null_Doesnt_Change_The_FeatureNameColumnName()
             {
                 // Arrange
                 var expectedSchema = "Feature";
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
                 // Act
-                actual.FeatureColumnName(null);
+                actual.FeatureNameColumnName(null);
 
                 // Assert
                 Assert.Equal(expectedSchema, actual.Schema());
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
             [Fact]
-            public void Calling_FeatureColumnName_With_An_Empty_String_Doesnt_Change_The_FeatureColumnName()
+            public void Calling_FeatureNameColumnName_With_An_Empty_String_Doesnt_Change_The_FeatureNameColumnName()
             {
                 // Arrange
                 var expectedSchema = "Feature";
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
                 // Act
-                actual.FeatureColumnName("");
+                actual.FeatureNameColumnName("");
 
                 // Assert
                 Assert.Equal(expectedSchema, actual.Schema());
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.IsActiveColumnName.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.IsActiveColumnName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "NewIsActiveColumn";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.Schema.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.Schema.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.ScopeColumnName.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.ScopeColumnName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "NewScopeColumn";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.TableName.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.TableName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "NewTableName";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var expectedTableName = "GlobalFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new GlobalDbContextConfiguration(_ => { });
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.cs
+++ b/tests/activators/efcore/Global/GlobalDbContextConfigurationTests.cs
@@ -14,7 +14,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
             var expectedTableName = "GlobalFeature";
             var expectedApplicationColumnName = "Application";
             var expectedScopeColumnName = "Scope";
-            var expectedFeatureColumnName = "Feature";
+            var expectedFeatureNameColumnName = "FeatureName";
             var expectedIsActiveColumnName = "IsActive";
 
             // Act
@@ -25,7 +25,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
             Assert.Equal(expectedTableName, actual.TableName());
             Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
             Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-            Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+            Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
             Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
         }
     }

--- a/tests/activators/efcore/Global/GlobalEntityFrameworkCoreActivatorTests.GetFeatureAsync.cs
+++ b/tests/activators/efcore/Global/GlobalEntityFrameworkCoreActivatorTests.GetFeatureAsync.cs
@@ -19,7 +19,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var activator = new GlobalEntityFrameworkCoreActivator(context);
 
                 // Act
-                var feature = await activator.GetFeatureAsync(new FeatureName("", "", ""));
+                var feature = await activator.GetFeatureAsync(new FeatureSpec("", "", ""));
 
                 // Assert
                 Assert.NotNull(feature);
@@ -37,7 +37,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 var activator = new GlobalEntityFrameworkCoreActivator(context);
 
                 // Act
-                var feature = await activator.GetFeatureAsync(new FeatureName("App3", "Scope3", "Feature3"));
+                var feature = await activator.GetFeatureAsync(new FeatureSpec("App3", "Scope3", "FeatureName3"));
 
                 // Assert
                 Assert.NotNull(feature);

--- a/tests/activators/efcore/Global/GlobalEntityFrameworkCoreActivatorTests.cs
+++ b/tests/activators/efcore/Global/GlobalEntityFrameworkCoreActivatorTests.cs
@@ -21,7 +21,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Global
                 {
                     Application = "App" + i,
                     Scope = "Scope" + i,
-                    Feature = "Feature" + i,
+                    FeatureName = "FeatureName" + i,
                     IsActive = i % 3 == 0
                 }));
             context.SaveChanges();

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.ApplicationColumnName.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.ApplicationColumnName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "NewApplicationColumn";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.FeatureColumnName.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.FeatureColumnName.cs
@@ -6,77 +6,77 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
     public partial class SpecificDbContextConfigurationTests
     {
         [Trait("Category", "UnitTest")]
-        public class FeatureColumnName
+        public class FeatureNameColumnName
         {
             [Fact]
-            public void Calling_FeatureColumnName_With_A_New_Name_Changes_The_FeatureColumnName()
+            public void Calling_FeatureNameColumnName_With_A_New_Name_Changes_The_FeatureNameColumnName()
             {
                 // Arrange
                 var expectedSchema = "Feature";
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "NewFeatureColumn";
+                var expectedFeatureNameColumnName = "NewFeatureColumn";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
                 // Act
-                actual.FeatureColumnName(expectedFeatureColumnName);
+                actual.FeatureNameColumnName(expectedFeatureNameColumnName);
 
                 // Assert
                 Assert.Equal(expectedSchema, actual.Schema());
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
             [Fact]
-            public void Calling_FeatureColumnName_With_A_Null_Doesnt_Change_The_FeatureColumnName()
+            public void Calling_FeatureNameColumnName_With_A_Null_Doesnt_Change_The_FeatureNameColumnName()
             {
                 // Arrange
                 var expectedSchema = "Feature";
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
                 // Act
-                actual.FeatureColumnName(null);
+                actual.FeatureNameColumnName(null);
 
                 // Assert
                 Assert.Equal(expectedSchema, actual.Schema());
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
             [Fact]
-            public void Calling_FeatureColumnName_With_An_Empty_String_Doesnt_Change_The_FeatureColumnName()
+            public void Calling_FeatureNameColumnName_With_An_Empty_String_Doesnt_Change_The_FeatureNameColumnName()
             {
                 // Arrange
                 var expectedSchema = "Feature";
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
                 // Act
-                actual.FeatureColumnName("");
+                actual.FeatureNameColumnName("");
 
                 // Assert
                 Assert.Equal(expectedSchema, actual.Schema());
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.IsActiveColumnName.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.IsActiveColumnName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "NewIsActiveColumn";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.Schema.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.Schema.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.ScopeColumnName.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.ScopeColumnName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "NewScopeColumn";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.TableName.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.TableName.cs
@@ -16,7 +16,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "NewTableName";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -28,7 +28,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -40,7 +40,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -52,7 +52,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
 
@@ -64,7 +64,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var expectedTableName = "SpecificFeature";
                 var expectedApplicationColumnName = "Application";
                 var expectedScopeColumnName = "Scope";
-                var expectedFeatureColumnName = "Feature";
+                var expectedFeatureNameColumnName = "FeatureName";
                 var expectedIsActiveColumnName = "IsActive";
                 var actual = new SpecificDbContextConfiguration<object>(_ => { }, "OtherColumnName", _ => feature => false);
 
@@ -76,7 +76,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 Assert.Equal(expectedTableName, actual.TableName());
                 Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
                 Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-                Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+                Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
                 Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             }
         }

--- a/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.cs
+++ b/tests/activators/efcore/Specific/SpecificDbContextConfigurationTests.cs
@@ -14,7 +14,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
             var expectedTableName = "SpecificFeature";
             var expectedApplicationColumnName = "Application";
             var expectedScopeColumnName = "Scope";
-            var expectedFeatureColumnName = "Feature";
+            var expectedFeatureNameColumnName = "FeatureName";
             var expectedIsActiveColumnName = "IsActive";
             var expectedOtherColumnName = "Other";
 
@@ -26,7 +26,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
             Assert.Equal(expectedTableName, actual.TableName());
             Assert.Equal(expectedApplicationColumnName, actual.ApplicationColumnName());
             Assert.Equal(expectedScopeColumnName, actual.ScopeColumnName());
-            Assert.Equal(expectedFeatureColumnName, actual.FeatureColumnName());
+            Assert.Equal(expectedFeatureNameColumnName, actual.FeatureNameColumnName());
             Assert.Equal(expectedIsActiveColumnName, actual.IsActiveColumnName());
             Assert.Equal(expectedOtherColumnName, actual.OtherColumnName());
         }

--- a/tests/activators/efcore/Specific/SpecificEntityFrameworkCoreActivatorTests.GetFeatureAsync.cs
+++ b/tests/activators/efcore/Specific/SpecificEntityFrameworkCoreActivatorTests.GetFeatureAsync.cs
@@ -24,9 +24,9 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 var activator = new SpecificEntityFrameworkCoreActivator<string>(context);
 
                 // Act
-                var actualFeature = await activator.GetFeatureAsync(new FeatureName(otherColumnValue.Replace("OtherColumn", "App"),
+                var actualFeature = await activator.GetFeatureAsync(new FeatureSpec(otherColumnValue.Replace("OtherColumn", "App"),
                     otherColumnValue.Replace("OtherColumn", "Scope"),
-                    otherColumnValue.Replace("OtherColumn", "Feature")));
+                    otherColumnValue.Replace("OtherColumn", "FeatureName")));
 
                 // Assert
                 Assert.NotNull(actualFeature);

--- a/tests/activators/efcore/Specific/SpecificEntityFrameworkCoreActivatorTests.cs
+++ b/tests/activators/efcore/Specific/SpecificEntityFrameworkCoreActivatorTests.cs
@@ -25,7 +25,7 @@ namespace MAF.FeaturesFlipping.Activators.EntityFrameworkCore.UnitTests.Specific
                 {
                     Application = "App" + i,
                     Scope = "Scope" + i,
-                    Feature = "Feature" + i,
+                    FeatureName = "FeatureName" + i,
                     OtherColumn = "OtherColumn" + i,
                     IsActive = i % 3 == 1 ? true : (i % 3 == 2 ? false : (bool?)null)
                 }));

--- a/tests/aspnet/aspnetcore/FeatureTagHelperTests.GetFeatureSpecToEvaluate.cs
+++ b/tests/aspnet/aspnetcore/FeatureTagHelperTests.GetFeatureSpecToEvaluate.cs
@@ -6,44 +6,44 @@ namespace MAF.FeaturesFlipping.AspNetCore.UnitTests
     public partial class FeatureTagHelperTests
     {
         [Trait("Category", "UnitTest")]
-        public class GetFeatureToEvaluate
+        public class GetFeatureSpecToEvaluate
         {
             [Fact]
-            public void Always_Take_The_Specified_FeatureName_When_Provided()
+            public void Always_Take_The_Specified_FeatureSpec_When_Provided()
             {
                 // Arrange
-                var expected = new FeatureName("App", "Scope", "Feature");
+                var expected = new FeatureSpec("App", "Scope", "FeatureName");
                 var featureServiceMock = new Mock<IFeatureService>();
                 var featureTagHelper = new FeatureTagHelper(featureServiceMock.Object)
                 {
-                    Feature = expected,
+                    FeatureSpec = expected,
                     Application = "MyApp",
                     Scope = "MyScope",
                     FeatureName = "MyFeature"
                 };
 
                 // Act
-                var actual = featureTagHelper.GetFeatureToEvaluate();
+                var actual = featureTagHelper.GetFeatureSpecToEvaluate();
 
                 // Assert
                 Assert.Equal(expected, actual);
             }
 
             [Fact]
-            public void Creates_A_New_FeatureName_When_No_One_Is_Provided()
+            public void Creates_A_New_FeatureSpec_When_No_One_Is_Provided()
             {
                 // Arrange
-                var expected = new FeatureName("App", "Scope", "Feature");
+                var expected = new FeatureSpec("App", "Scope", "FeatureName");
                 var featureServiceMock = new Mock<IFeatureService>();
                 var featureTagHelper = new FeatureTagHelper(featureServiceMock.Object)
                 {
                     Application = expected.Application,
                     Scope = expected.Scope,
-                    FeatureName = expected.Feature
+                    FeatureName = expected.FeatureName
                 };
 
                 // Act
-                var actual = featureTagHelper.GetFeatureToEvaluate();
+                var actual = featureTagHelper.GetFeatureSpecToEvaluate();
 
                 // Assert
                 Assert.Equal(expected, actual);

--- a/tests/aspnet/aspnetcore/FeatureTagHelperTests.ProcessAsync.cs
+++ b/tests/aspnet/aspnetcore/FeatureTagHelperTests.ProcessAsync.cs
@@ -45,7 +45,7 @@ namespace MAF.FeaturesFlipping.AspNetCore.UnitTests
                 var context = MakeTagHelperContext();
                 var output = MakeTagHelperOutput("feature", childContent: childContent);
                 var featureServiceMock = new Mock<IFeatureService>();
-                featureServiceMock.Setup(_ => _.IsFeatureActiveAsync(It.IsAny<FeatureName>()))
+                featureServiceMock.Setup(_ => _.IsFeatureActiveAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(false);
                 var tagHelper = new FeatureTagHelper(featureServiceMock.Object);
 
@@ -68,7 +68,7 @@ namespace MAF.FeaturesFlipping.AspNetCore.UnitTests
                 var context = MakeTagHelperContext();
                 var output = MakeTagHelperOutput("feature", childContent: childContent);
                 var featureServiceMock = new Mock<IFeatureService>();
-                featureServiceMock.Setup(_ => _.IsFeatureActiveAsync(It.IsAny<FeatureName>()))
+                featureServiceMock.Setup(_ => _.IsFeatureActiveAsync(It.IsAny<FeatureSpec>()))
                     .ReturnsAsync(true);
                 var tagHelper = new FeatureTagHelper(featureServiceMock.Object);
 


### PR DESCRIPTION
Rename the type `MAF.FeaturesFlipping.FeatureName` to `MAF.FeaturesFlipping.FeatureSpec`.
Rename the property `Feature` of type `FeatureSpec` to `FeatureSpec` and property of type `string` to `FeatureName`.