### PR TITLE
Delay and cache the creation of the IFeatureContext

### DIFF
--- a/src/MAF.FeaturesFlipping.Extensibility.FeatureContext.Abstractions/IFeatureContextPartFactory.cs
+++ b/src/MAF.FeaturesFlipping.Extensibility.FeatureContext.Abstractions/IFeatureContextPartFactory.cs
@@ -1,10 +1,11 @@
-﻿using MAF.FeaturesFlipping.Extensibility.Activators;
+﻿using System.Threading.Tasks;
+using MAF.FeaturesFlipping.Extensibility.Activators;
 
 namespace MAF.FeaturesFlipping.Extensibility.FeatureContext
 {
     public interface IFeatureContextPartFactory
     {
-        void AddFeatureContextPart(IFeatureContext featureContext);
+        Task AddFeatureContextPartAsync(IFeatureContext featureContext);
         void ReleaseFeatureContextPart(IFeatureContext featureContext);
     }
 }

--- a/src/MAF.FeaturesFlipping/AsyncLazy`1.cs
+++ b/src/MAF.FeaturesFlipping/AsyncLazy`1.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace MAF.FeaturesFlipping
+{
+    internal class AsyncLazy<T> : Lazy<Task<T>>
+    {
+        public AsyncLazy(Func<T> valueFactory) :
+            base(() => Task.Factory.StartNew(valueFactory))
+        {
+        }
+
+        public AsyncLazy(Func<Task<T>> taskFactory) :
+            base(() => Task.Factory.StartNew(() => taskFactory()).Unwrap())
+        {
+        }
+        public TaskAwaiter<T> GetAwaiter() { return Value.GetAwaiter(); }
+    }
+}

--- a/src/MAF.FeaturesFlipping/FeatureContextAccessor.cs
+++ b/src/MAF.FeaturesFlipping/FeatureContextAccessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using MAF.FeaturesFlipping.Extensibility.Activators;
 using MAF.FeaturesFlipping.Extensibility.FeatureContext;
 
@@ -7,28 +8,41 @@ namespace MAF.FeaturesFlipping
     public sealed class FeatureContextAccessor : IFeatureContextAccessor
     {
         private readonly IEnumerable<IFeatureContextPartFactory> _featureContextPartFactories;
+        private AsyncLazy<IFeatureContext> _featureContextLazy;
+        private bool _isDisposed;
 
         public FeatureContextAccessor(IEnumerable<IFeatureContextPartFactory> featureContextPartFactories)
         {
             _featureContextPartFactories = featureContextPartFactories;
+            _featureContextLazy = new AsyncLazy<IFeatureContext>(async () => await CreateFeatureContextAsync());
         }
 
-        public IFeatureContext GetCurrentFeatureContext()
+        public async Task<IFeatureContext> GetCurrentFeatureContextAsync()
+        {
+            return await _featureContextLazy;
+        }
+        private async Task<IFeatureContext> CreateFeatureContextAsync()
         {
             var featureContext = new FeatureContext();
             foreach (var featureContextPartFactory in _featureContextPartFactories)
             {
-                featureContextPartFactory.AddFeatureContextPart(featureContext);
+                await featureContextPartFactory.AddFeatureContextPartAsync(featureContext);
             }
             return featureContext;
         }
 
-        public void DisposeFeatureContext(IFeatureContext featureContext)
+        public void Dispose()
         {
+            if (_isDisposed)
+            {
+                return;
+            }
+            var featureContext = _featureContextLazy.Value.Result;
             foreach (var featureContextPartFactory in _featureContextPartFactories)
             {
                 featureContextPartFactory.ReleaseFeatureContextPart(featureContext);
             }
+            _isDisposed = true;
         }
     }
 }

--- a/src/MAF.FeaturesFlipping/IFeatureContextAccessor.cs
+++ b/src/MAF.FeaturesFlipping/IFeatureContextAccessor.cs
@@ -1,10 +1,11 @@
+using System;
+using System.Threading.Tasks;
 using MAF.FeaturesFlipping.Extensibility.Activators;
 
 namespace MAF.FeaturesFlipping
 {
-    public interface IFeatureContextAccessor
+    public interface IFeatureContextAccessor : IDisposable
     {
-        IFeatureContext GetCurrentFeatureContext();
-        void DisposeFeatureContext(IFeatureContext featureContext);
+        Task<IFeatureContext> GetCurrentFeatureContextAsync();
     }
 }

--- a/tests/MAF.FeaturesFlipping.UnitTests/FeatureServiceTests.IsFeatureActiveAsync.cs
+++ b/tests/MAF.FeaturesFlipping.UnitTests/FeatureServiceTests.IsFeatureActiveAsync.cs
@@ -16,8 +16,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
                 var inactiveFeatureMock = new Mock<IFeature>();
                 inactiveFeatureMock.Setup(_ => _.GetStatusAsync(It.IsAny<IFeatureContext>()))
                     .ReturnsAsync(FeatureActivationStatus.Inactive);
@@ -36,6 +36,7 @@ namespace MAF.FeaturesFlipping.UnitTests
 
                 // Act
                 var actual = featureService.IsFeatureActiveAsync(new FeatureSpec("", "", "")).Result;
+                featureService.Dispose();
 
                 // Assert
                 Assert.False(actual);
@@ -46,8 +47,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
 
                 var inactiveFeatureMock = new Mock<IFeature>();
                 inactiveFeatureMock.Setup(_ => _.GetStatusAsync(It.IsAny<IFeatureContext>()))
@@ -92,8 +93,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
                 var featureService = new FeatureService(Enumerable.Empty<IFeatureActivator>(),
                     featureContextAccessorMock.Object);
 
@@ -108,8 +109,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
                 var featureActivatorMock = new Mock<IFeatureActivator>();
                 featureActivatorMock
                     .Setup(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()))
@@ -128,8 +129,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
 
                 var activeFeatureMock = new Mock<IFeature>();
                 activeFeatureMock.Setup(_ => _.GetStatusAsync(It.IsAny<IFeatureContext>()))
@@ -157,8 +158,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
 
                 var activeFeatureMock = new Mock<IFeature>();
                 activeFeatureMock.Setup(_ => _.GetStatusAsync(It.IsAny<IFeatureContext>()))
@@ -195,8 +196,8 @@ namespace MAF.FeaturesFlipping.UnitTests
             {
                 // Arrange
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(() => null);
+                featureContextAccessorMock.Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(() => null);
 
                 var activeFeatureMock = new Mock<IFeature>();
                 activeFeatureMock.Setup(_ => _.GetStatusAsync(It.IsAny<IFeatureContext>()))
@@ -236,9 +237,9 @@ namespace MAF.FeaturesFlipping.UnitTests
                 var featureContextMock = new Mock<IFeatureContext>();
                 var mockSequence = new MockSequence();
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(featureContextMock.Object);
-                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.DisposeFeatureContext(featureContextMock.Object))
+                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(featureContextMock.Object);
+                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.Dispose())
                     .Verifiable();
 
                 var notSetFeatureMock = new Mock<IFeature>();
@@ -265,12 +266,13 @@ namespace MAF.FeaturesFlipping.UnitTests
 
                 // Act
                 var actual = await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", ""));
+                featureService.Dispose();
 
                 // Assert
                 Assert.True(actual);
 
-                featureContextAccessorMock.Verify(_ => _.GetCurrentFeatureContext(), Times.Once);
-                featureContextAccessorMock.Verify(_ => _.DisposeFeatureContext(featureContextMock.Object), Times.Once);
+                featureContextAccessorMock.Verify(_ => _.GetCurrentFeatureContextAsync(), Times.Once);
+                featureContextAccessorMock.Verify(_ => _.Dispose(), Times.Once);
             }
 
             [Theory]
@@ -284,9 +286,9 @@ namespace MAF.FeaturesFlipping.UnitTests
                 var featureContextMock = new Mock<IFeatureContext>();
                 var mockSequence = new MockSequence();
                 var featureContextAccessorMock = new Mock<IFeatureContextAccessor>();
-                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.GetCurrentFeatureContext())
-                    .Returns(featureContextMock.Object);
-                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.DisposeFeatureContext(featureContextMock.Object))
+                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.GetCurrentFeatureContextAsync())
+                    .ReturnsAsync(featureContextMock.Object);
+                featureContextAccessorMock.InSequence(mockSequence).Setup(_ => _.Dispose())
                     .Verifiable();
 
                 var featureMock = new Mock<IFeature>();
@@ -305,13 +307,14 @@ namespace MAF.FeaturesFlipping.UnitTests
                 // Act
                 var actual = await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", ""));
                 var actual2 = await featureService.IsFeatureActiveAsync(new FeatureSpec("", "", ""));
+                featureService.Dispose();
 
                 // Assert
                 Assert.Equal(expected, actual);
                 Assert.Equal(expected, actual2);
 
-                featureContextAccessorMock.Verify(_ => _.GetCurrentFeatureContext(), Times.Once);
-                featureContextAccessorMock.Verify(_ => _.DisposeFeatureContext(featureContextMock.Object), Times.Once);
+                featureContextAccessorMock.Verify(_ => _.GetCurrentFeatureContextAsync(), Times.Once);
+                featureContextAccessorMock.Verify(_ => _.Dispose(), Times.Once);
                 featureActivatorMock.Verify(_ => _.GetFeatureAsync(It.IsAny<FeatureSpec>()), Times.Once);
             }
         }


### PR DESCRIPTION
Make construction of IFeatureContext async
Lazy load the context once per scope
Release IFeatureContext part when disposing

fixes #9 